### PR TITLE
Minor fix to parsing of scenario/model lists

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^\.claude$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3143448'
+ValidationKey: '3186800'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
@@ -13,3 +13,4 @@ allowLinterWarnings: yes
 enforceVersionUpdate: no
 skipCoverage: no
 AutocreateCITATION: yes
+UsePkgDown: yes

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,12 +3,8 @@
 on:
   push:
     branches: [main, master]
-  pull_request:
-  release:
-    types: [published]
-  workflow_dispatch:
 
-name: pkgdown.yaml
+name: pkgdown
 
 permissions: read-all
 
@@ -30,7 +26,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-          extra-repositories: "https://pik-piam.r-universe.dev"
+          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -38,7 +34,7 @@ jobs:
           needs: website
 
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE)
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamValidation: Validation Tools for PIK-PIAM'
-version: 0.15.4
-date-released: '2025-11-20'
+version: 0.15.5
+date-released: '2026-04-17'
 abstract: The piamValidation package provides validation tools for the Potsdam Integrated
   Assessment Modelling environment.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamValidation
 Title: Validation Tools for PIK-PIAM
-Version: 0.15.4
-Date: 2025-11-20
+Version: 0.15.5
+Date: 2026-04-17
 Authors@R:
     c(person("Pascal", "Weigmann",, "pascal.weigmann@pik-potsdam.de", role = c("aut", "cre"),
       comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0001-8801-173X")),

--- a/R/combineData.R
+++ b/R/combineData.R
@@ -26,9 +26,9 @@ combineData <- function(scenData, cfgRow, histData = NULL) {
   # create filters ####
   # check whether regions, periods, scenarios are specified, else use all
   mod <- if (is.na(c$model))    all_mod else
-    strsplit(c$model, split = ", |, ")[[1]]
+    strsplit(c$model, split = ", |,")[[1]]
   sce <- if (is.na(c$scenario)) all_sce else
-    strsplit(c$scenario, split = ", |, ")[[1]]
+    strsplit(c$scenario, split = ", |,")[[1]]
   reg <- if (is.na(c$region))   all_reg else
     strsplit(c$region, split = ", |,")[[1]]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Validation Tools for PIK-PIAM
 
-R package **piamValidation**, version **0.15.4**
+R package **piamValidation**, version **0.15.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamValidation)](https://cran.r-project.org/package=piamValidation) [![R build status](https://github.com/pik-piam/piamValidation/workflows/check/badge.svg)](https://github.com/pik-piam/piamValidation/actions) [![codecov](https://codecov.io/gh/pik-piam/piamValidation/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamValidation) [![r-universe](https://pik-piam.r-universe.dev/badges/piamValidation)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Pascal Weigmann <pascal.weigmann@
 
 To cite package **piamValidation** in publications use:
 
-Weigmann P, Richters O, Lécuyer F, Koch J (2025). "piamValidation: Validation Tools for PIK-PIAM." Version: 0.15.4, <https://pik-piam.github.io/piamValidation>.
+Weigmann P, Richters O, Lécuyer F, Koch J (2026). "piamValidation: Validation Tools for PIK-PIAM." Version: 0.15.5, <https://pik-piam.github.io/piamValidation%20https://github.com/pik-piam/piamValidation>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,9 +55,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamValidation: Validation Tools for PIK-PIAM},
   author = {Pascal Weigmann and Oliver Richters and Fabrice Lécuyer and Johannes Koch},
-  date = {2025-11-20},
-  year = {2025},
+  date = {2026-04-17},
+  year = {2026},
   url = {https://pik-piam.github.io/piamValidation https://github.com/pik-piam/piamValidation},
-  note = {Version: 0.15.4},
+  note = {Version: 0.15.5},
 }
 ```

--- a/tests/testthat/test-useCases.R
+++ b/tests/testthat/test-useCases.R
@@ -40,6 +40,12 @@ test_that("all use cases generally work", {
   expect_equal(df$check,
                c("green", "green"))
 
+  # multiple model comparisons ####
+  selected_config <- cfg[3, ]
+  selected_config$model <- "Model1,Model2"
+  df <- validateScenarios(dat_path, selected_config)
+  expect_equal(df$check, c("green", "green", "green", "green"))
+
   # relative scenario comparison ####
   df <- validateScenarios(dat_path, cfg[4, ])
   expect_equal(df$ref_value_min,
@@ -50,6 +56,12 @@ test_that("all use cases generally work", {
                tolerance = 0.0001)
   expect_equal(df$check,
                c("green", "green"))
+
+  # multiple scenario comparisons ####
+  selected_config <- cfg[4, ]
+  selected_config$scenario <- "Scen1,Scen2"
+  df <- validateScenarios(dat_path, selected_config)
+  expect_equal(df$check, c("green", "green", "green", "green"))
 
   # relative period comparison ####
   df <- validateScenarios(dat_path, cfg[5, ])
@@ -116,4 +128,4 @@ test_that("all use cases generally work", {
   # -> growthrate doesnt work for single time step atm, see
   # https://github.com/pik-piam/piamValidation/issues/21
 
-  })
+})


### PR DESCRIPTION
The scenario/model columns only accepted a comma followed by a space, which should probably have been "comma space" or "comma".

I have tried to keep the pkgdown config untouched. If you want to change to the lucode2 config, I can change that however. :slightly_smiling_face: 